### PR TITLE
Fix regex in parseFunction for anonymous functions.

### DIFF
--- a/lib/tiny-jsonrpc/server.js
+++ b/lib/tiny-jsonrpc/server.js
@@ -46,7 +46,7 @@ function functionSnippet(fn) {
 }
 
 function parseFunction(fn) {
-  var parsed = fn.toString().match(/function\s+(\w+)?\((.*)\)/);
+  var parsed = fn.toString().match(/function(?:\s+|\s+(\w+))?\s*\((.*)\)/);
 
   if (!parsed) {
     throw 'Cannot parse function: ' + functionSnippet(fn);


### PR DESCRIPTION
Previously, the regex in the `parseFunction` wasn't able to parse the string `function() {}`. However, when there was a space between `function` and `(` it was fine.

This fixes an issue in IE, where the function was this:

```js
function() {
    [native code]
}
```